### PR TITLE
Fix nextjs builds if there are no "meta" values

### DIFF
--- a/example/pages/no-meta.tsx
+++ b/example/pages/no-meta.tsx
@@ -1,0 +1,15 @@
+import { InferGetServerSidePropsType } from 'next';
+
+export const getStaticProps = async () => {
+  return {
+    props: {
+      rawField: 'test'
+    },
+  };
+};
+
+export default function NoMetaProps(
+  props: InferGetServerSidePropsType<typeof getStaticProps>
+) {
+  return 'props.rawField is String: ' + props.rawField;
+}

--- a/example/tests/no-meta.ts
+++ b/example/tests/no-meta.ts
@@ -1,0 +1,8 @@
+import { Selector } from 'testcafe';
+
+fixture`No meta`.page`http://localhost:3000/no-meta`;
+
+test('Raw object is built', async (t) => {
+  const result = Selector('#__next');
+  await t.expect(result.innerText).eql('props.rawField is String: test');
+});

--- a/src/tools.tsx
+++ b/src/tools.tsx
@@ -9,9 +9,17 @@ export function withSuperJSONProps<P>(
 ): GetServerSideProps<SuperJSONResult> {
   return async function withSuperJSON(...args) {
     const result = await gssp(...args);
+    const { json, meta } = SuperJSON.serialize(result.props as any)
+    
+    const props: SuperJSONResult = { json }
+
+    if (Boolean(meta)) {
+      props.meta = meta
+    }
+    
     return {
       ...result,
-      props: SuperJSON.serialize(result.props as any),
+      props
     };
   };
 }


### PR DESCRIPTION
Resolves #5 

Alternatively, we could fix this upstream in `superjson` if we'd rather do that, although I think that would involve [changing `meta`](https://github.com/blitz-js/superjson/blob/main/src/index.ts#L21) to default to `null` if there's no transformed properties.