### PR TITLE
Prevents loss of static methods

### DIFF
--- a/example/pages/_app.js
+++ b/example/pages/_app.js
@@ -1,7 +1,8 @@
-import '../styles/globals.css'
+import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  const getLayout = Component.getLayout || ((page) => page);
+  return getLayout(<Component {...pageProps} />);
 }
 
-export default MyApp
+export default MyApp;

--- a/example/pages/with-static-methods.tsx
+++ b/example/pages/with-static-methods.tsx
@@ -1,0 +1,17 @@
+import type { GetStaticProps, InferGetStaticPropsType } from 'next';
+
+export async function getStaticProps() {
+  return {
+    props: {
+      date: new Date(0),
+    },
+  };
+}
+
+const Page = (props: InferGetStaticPropsType<typeof getStaticProps>) => {
+  return 'props.date is Date: ' + (props.date instanceof Date);
+};
+
+Page.getLayout = (page) => <>This is part of the static method {page}</>;
+
+export default Page;

--- a/example/tests/with-static-methods.ts
+++ b/example/tests/with-static-methods.ts
@@ -1,0 +1,10 @@
+import { Selector } from 'testcafe';
+
+fixture`With Static Methods`.page`http://localhost:3000/with-static-methods`;
+
+test('Static methods are preserved', async (t) => {
+  const result = Selector('#__next');
+  await t
+    .expect(result.innerText)
+    .eql('This is part of the static method props.date is Date: true');
+});

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1112,6 +1112,14 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json-schema@^7.0.4":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
@@ -1146,6 +1154,14 @@
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
+"@types/react@*":
+  version "16.9.49"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
+  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/react@^16.9.44":
   version "16.9.44"
@@ -1791,10 +1807,12 @@ babel-plugin-dynamic-import-node@^2.3.3:
     object.assign "^4.1.0"
 
 "babel-plugin-superjson-next@file:..":
-  version "0.1.4"
+  version "0.1.5"
   dependencies:
     "@babel/core" "^7.11.0"
     "@babel/helper-module-imports" "^7.10.4"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    hoist-non-react-statics "^3.3.2"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -4179,6 +4197,13 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -6205,7 +6230,7 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@16.13.1, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.11.0",
-    "@babel/helper-module-imports": "^7.10.4"
+    "@babel/helper-module-imports": "^7.10.4",
+    "@types/hoist-non-react-statics": "^3.3.1",
+    "hoist-non-react-statics": "^3.3.2"
   }
 }

--- a/src/tools.tsx
+++ b/src/tools.tsx
@@ -1,4 +1,5 @@
 import SuperJSON from 'superjson';
+import * as hoistNonReactStatics from 'hoist-non-react-statics';
 import type { GetServerSideProps } from 'next';
 import * as React from 'react';
 
@@ -10,13 +11,13 @@ export function withSuperJSONProps<P>(
   return async function withSuperJSON(...args) {
     const result = await gssp(...args);
     const { json, meta } = SuperJSON.serialize(result.props as any)
-    
+
     const props: SuperJSONResult = { json }
 
     if (Boolean(meta)) {
       props.meta = meta
     }
-    
+
     return {
       ...result,
       props
@@ -27,8 +28,12 @@ export function withSuperJSONProps<P>(
 export function withSuperJSONPage<P>(
   Page: React.ComponentType<P>
 ): React.ComponentType<SuperJSONResult> {
-  return function WithSuperJSON(serializedProps: any) {
+  const WithSuperJSON = (serializedProps: any) => {
     const props = (SuperJSON.deserialize(serializedProps) as unknown) as P;
     return <Page {...props} />;
   };
+
+  hoistNonReactStatics(WithSuperJSON, Page);
+
+  return WithSuperJSON;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -1520,6 +1528,14 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@*":
+  version "16.9.49"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
+  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/react@^16.9.44":
   version "16.9.44"
@@ -3907,6 +3923,13 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
@@ -6064,7 +6087,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
I was testing this babel plugin in one of our projects with blitz.js and noticed that whenever the WithSuperJSON HOC was used, the getLayout method was lost (as well as other static methods).

The fix is pretty simple and referenced here https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over

This PR adds `hoistNonReactStatics` as recommended and a test in the examples folder.