### PR TITLE
Add repository metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,14 @@
   },
   "name": "babel-plugin-superjson-next",
   "author": "Simon Knott",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blitz-js/babel-plugin-superjson-next.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blitz-js/babel-plugin-superjson-next/issues"
+  },
+  "homepage": "https://github.com/blitz-js/babel-plugin-superjson-next#readme",
   "module": "dist/babel-plugin-superjson-next.esm.js",
   "devDependencies": {
     "@babel/core": "^7.12.17",


### PR DESCRIPTION
Hi there! Thank you for this awesome plugin.

I just added the repository metadata to the `package.json` file so that it appears when (for example) using the `yarn outdated` command.

This is how it appears right now without the metadata:

![image](https://user-images.githubusercontent.com/7624090/108927762-eb0c3e80-760e-11eb-9e4d-99804c9daf94.png)


