### PR TITLE
Fix README npm badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 <a href="#contributors"><img src="https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square" alt="All Contributors"/></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-  <a href="https://www.npmjs.com/package/otion">
+  <a href="https://www.npmjs.com/package/babel-plugin-superjson-next">
     <img alt="npm" src="https://img.shields.io/npm/v/babel-plugin-superjson-next" />
   </a>
 


### PR DESCRIPTION
Hi again!

Now I noticed that the npm badge on README is pointing to another repo. This PR is just that 🤣.

I also noticed that the CI badge is using the badge of the [SuperJSON repository](https://github.com/blitz-js/superjson), not this one. I haven't changed that, I wanted to ask before changing it 😄.