### PR TITLE
create `deserializeProps` utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { NodePath, PluginObj, PluginPass } from '@babel/core';
 import { addNamed as addNamedImport } from '@babel/helper-module-imports';
 import {
+  arrayExpression,
   callExpression,
   ClassDeclaration,
   classExpression,
@@ -10,17 +11,16 @@ import {
   functionExpression,
   isClassDeclaration,
   isExportDefaultDeclaration,
-  isExportNamedDeclaration,
   isFunctionDeclaration,
   isFunctionExpression,
   isIdentifier,
   isVariableDeclaration,
+  stringLiteral,
   variableDeclaration,
   variableDeclarator,
-  arrayExpression,
-  stringLiteral,
 } from '@babel/types';
 import * as nodePath from 'path';
+import { deserializeProps } from './tools';
 
 function functionDeclarationToExpression(declaration: FunctionDeclaration) {
   return functionExpression(
@@ -233,3 +233,5 @@ function superJsonWithNext(): PluginObj {
 }
 
 export default superJsonWithNext;
+
+export { deserializeProps };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ import {
   variableDeclarator,
 } from '@babel/types';
 import * as nodePath from 'path';
-import { deserializeProps } from './tools';
 
 function functionDeclarationToExpression(declaration: FunctionDeclaration) {
   return functionExpression(
@@ -233,5 +232,3 @@ function superJsonWithNext(): PluginObj {
 }
 
 export default superJsonWithNext;
-
-export { deserializeProps };

--- a/src/tools.tsx
+++ b/src/tools.tsx
@@ -1,7 +1,7 @@
-import SuperJSON from 'superjson';
 import * as hoistNonReactStatics from 'hoist-non-react-statics';
 import type { GetServerSideProps } from 'next';
 import * as React from 'react';
+import SuperJSON from 'superjson';
 
 type SuperJSONProps<P> = P & {
   _superjson?: ReturnType<typeof SuperJSON.serialize>['meta'];
@@ -49,16 +49,16 @@ export function withSuperJSONProps<P>(
   };
 }
 
+export function deserializeProps<P>(serializedProps: SuperJSONProps<P>): P {
+  const { _superjson, ...props } = serializedProps;
+  return SuperJSON.deserialize({ json: props as any, meta: _superjson });
+}
+
 export function withSuperJSONPage<P>(
   Page: React.ComponentType<P>
 ): React.ComponentType<SuperJSONProps<P>> {
   function WithSuperJSON(serializedProps: SuperJSONProps<P>) {
-    const { _superjson, ...props } = serializedProps;
-    return (
-      <Page
-        {...SuperJSON.deserialize({ json: props as any, meta: _superjson })}
-      />
-    );
+    return <Page {...deserializeProps<P>(serializedProps)} />;
   }
 
   hoistNonReactStatics(WithSuperJSON, Page);


### PR DESCRIPTION
Fixes #93

This PR is for exporting this new `deserializeProps` utility that can be used for deserializing the props on `_app.tsx` file.

Example:

```tsx
import { deserializeProps } from "babel-plugin-superjson-next";
```

```tsx
const { dehydratedState, ...deserializedProps } = deserializeProps(pageProps);

return (
  <QueryClientProvider client={queryClient}>
    <Hydrate state={dehydratedState}>
      <Component {...deserializedProps} />
    </Hydrate>
  </QueryClientProvider>
);
```