### PR TITLE
Fix skipped api-something pages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,7 @@ function shouldBeSkipped(filePath: string) {
   if (!filePath.includes('pages' + nodePath.sep)) {
     return true;
   }
-  if (filePath.includes('pages' + nodePath.sep + 'api')) {
+  if (filePath.includes('pages' + nodePath.sep + 'api' + nodePath.sep)) {
     return true;
   }
   return filesToSkip.some((fileToSkip) => filePath.includes(fileToSkip));

--- a/test/pages/apiculture or api-something/code.js
+++ b/test/pages/apiculture or api-something/code.js
@@ -1,0 +1,17 @@
+export async function getServerSideProps() {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+}
+
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/test/pages/apiculture or api-something/output.js
+++ b/test/pages/apiculture or api-something/output.js
@@ -1,0 +1,24 @@
+import { withSuperJSONPage as _withSuperJSONPage } from 'babel-plugin-superjson-next/tools';
+import { withSuperJSONProps as _withSuperJSONProps } from 'babel-plugin-superjson-next/tools';
+export const getServerSideProps = _withSuperJSONProps(
+  async function getServerSideProps() {
+    const products = [
+      {
+        name: 'Hat',
+        publishedAt: new Date(0),
+      },
+    ];
+    return {
+      props: {
+        products,
+      },
+    };
+  },
+  ['smth']
+);
+
+function Page({ products }) {
+  return JSON.stringify(products);
+}
+
+export default _withSuperJSONPage(Page);


### PR DESCRIPTION
Currently, pages that start with `api` (like `apis` or `apiculture`) are being skipped by the plugin.
This PR fixes the issue by adding the missing `nodePath.sep` in the skip condition and a test.