### PR TITLE
feat: Allow props to be exported from other files

### DIFF
--- a/test/pages/separate files/code.js
+++ b/test/pages/separate files/code.js
@@ -1,0 +1,5 @@
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}
+
+export { getStaticProps } from './props';

--- a/test/pages/separate files/output.js
+++ b/test/pages/separate files/output.js
@@ -1,0 +1,10 @@
+import { withSuperJSONPage as _withSuperJSONPage } from 'babel-plugin-superjson-next/tools';
+import { withSuperJSONProps as _withSuperJSONProps } from 'babel-plugin-superjson-next/tools';
+import { getStaticProps } from './props';
+
+function Page({ products }) {
+  return JSON.stringify(products);
+}
+
+export const getStaticProps = _withSuperJSONProps(getStaticProps);
+export default _withSuperJSONPage(Page);

--- a/test/pages/separate files/props.js
+++ b/test/pages/separate files/props.js
@@ -1,0 +1,14 @@
+export const getStaticProps = async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+
+  return {
+    props: {
+      products,
+    },
+  };
+};


### PR DESCRIPTION
Fixes #121 and allows for props to exported in the following manner

```tsx
export {getStaticProps} from '../props';

export default function Page(props) {
	// ...
}
```