### PR TITLE
Update: from npm v7, no need to install superjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ Install the library with your package manager of choice, e.g.:
 npm install babel-plugin-superjson-next
 ```
 
-Since this is a companion to [SuperJSON](https://github.com/blitz-js/superjson),
+Since this is a companion to [SuperJSON](https://github.com/blitz-js/superjson), 
+
 make sure it's also installed:
 
+`(If you use npm 7 or later, you can skip this since from npm v7 automatically installing peer dependencies)`
 ```
 npm install superjson
 ```

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ npm install babel-plugin-superjson-next
 Since this is a companion to [SuperJSON](https://github.com/blitz-js/superjson), 
 make sure it's also installed:
 
-`(If you use npm 7 or later, you can skip this since from npm v7 automatically installing peer dependencies)`
 ```
 npm install superjson
 ```
+
+> for npm 7 or later, you can skip this since from npm v7 automatically installs peer dependencies
 
 Add the plugin to your `.babelrc`.
 If you don't have one, create it.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ npm install babel-plugin-superjson-next
 ```
 
 Since this is a companion to [SuperJSON](https://github.com/blitz-js/superjson), 
-
 make sure it's also installed:
 
 `(If you use npm 7 or later, you can skip this since from npm v7 automatically installing peer dependencies)`


### PR DESCRIPTION
this pr is for resolve [issue#124](https://github.com/blitz-js/babel-plugin-superjson-next/issues/124).
from npm 7, peer dependencies automatyically installed, so I guess it would be little confusing to someone use npm v7 or later.