### PR TITLE
fix: make ESM module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
         node:
-          - 14
+          - 20
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.6-0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
   "version": "0.4.5",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./tools": "./dist/tools.js"
+  },
   "files": [
-    "dist",
-    "tools.js"
+    "dist"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=16"
   },
   "scripts": {
     "build": "tsc",
@@ -37,7 +41,6 @@
     "url": "https://github.com/blitz-js/babel-plugin-superjson-next/issues"
   },
   "homepage": "https://github.com/blitz-js/babel-plugin-superjson-next#readme",
-  "module": "dist/babel-plugin-superjson-next.esm.js",
   "devDependencies": {
     "@babel/core": "^7.13.16",
     "@testing-library/react-native": "^7.2.0",
@@ -60,7 +63,7 @@
   },
   "peerDependencies": {
     "next": ">=9.0.0",
-    "superjson": "1.x"
+    "superjson": "2.x"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.13.12",

--- a/tools.js
+++ b/tools.js
@@ -1,1 +1,0 @@
-module.exports = require("./dist/tools.js")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": true,
-    "target": "ES5",
+    "target": "ES6",
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,


### PR DESCRIPTION
Closes https://github.com/blitz-js/babel-plugin-superjson-next/issues/145.

The code we were compiling into `dist` was CJS, not ESM. But when the user installed SuperJSON 2, which is ESM-only, it tried `require`-ing it. That failed, see #145. This PR fixes that, by making this package (including `/tools`) an ESM package as well.